### PR TITLE
expand on install instructions

### DIFF
--- a/sphinx/install.rst
+++ b/sphinx/install.rst
@@ -6,18 +6,19 @@ Installing VDJtools
 Installing binaries
 ^^^^^^^^^^^^^^^^^^^
 
-First make sure that you have installed Java Runtime Environment (JRE) v1.8 by running 
-``java -version`` (you can get it
-`here <http://www.oracle.com/technetwork/java/javase/downloads/java-se-jre-7-download-432155.html>`__). 
-Then download and unpack the binaries from
-the `latest
+First make sure that you have installed Java Runtime Environment (JRE) v1.8 by running
+``java -version``.  Any recent Linux distribution will provide it via its
+package manager.  If not, or if your system is running MacOSX or Windows,
+download the JRE from `Oracle <http://java.com/en/download/>`__.
+
+Then download and unpack the VDJtools binaries from the `latest
 release <https://github.com/mikessh/vdjtools/releases/latest>`__.
 
-The program is then run by executing the following line
+The program is then run by executing the following line:
 
 .. code:: bash
 
-    java -jar vdjtools-X.X.X.jar
+    java -jar path-to-vdjtools-X.X.X.jar
 
 where ``X.X.X`` stands for the VDJtools version (omitted further
 for simplicity). This will bring up the list of available routines. To
@@ -44,9 +45,9 @@ Installation can be performed using `Homebrew <http://brew.sh/>`__ package manag
     brew tap homebrew/science
     brew tap mikessh/repseq
     brew install vdjtools
-	
+
 Note that this sets ``vdjtools`` as a shortcut for ``java -jar vdjtools-X.X.X.jar``. JVM arguments
-such as ``-Xmx`` can be still passed to the script, e.g. ``vdjtools -Xmx20G CalcBasicStats ...``. 
+such as ``-Xmx`` can be still passed to the script, e.g. ``vdjtools -Xmx20G CalcBasicStats ...``.
 
 Setting up plotting routines
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,8 +62,8 @@ programming language and make sure that the
 
 runs successfully. Note that all R scripts were tested under R version 3.1.0.
 
-In case not using the pre-compiled ``*.win.zip`` package / Homebrew installation, 
-one needs to additionally install R dependencies to a local library by 
+In case not using the pre-compiled ``*.win.zip`` package / Homebrew installation,
+one needs to additionally install R dependencies to a local library by
 running the :ref:`rinstall` routine:
 
 .. code:: bash
@@ -70,21 +71,21 @@ running the :ref:`rinstall` routine:
     java -jar vdjtools.jar Rinstall
 
 This would also print the list of required R modules, so in case
-``Rinstall`` fails, they could be installed manually by running the following 
+``Rinstall`` fails, they could be installed manually by running the following
 command in R:
 
 .. code:: r
 
-    install.packages(c("reshape2", "FField", "reshape", "gplots", 
-	                   "gridExtra", "circlize", "ggplot2", "grid", 
-					   "VennDiagram", "ape", "MASS", "plotrix", 
-					   "RColorBrewer", "scales"))
-					   
+    install.packages(c("reshape2", "FField", "reshape", "gplots",
+                       "gridExtra", "circlize", "ggplot2", "grid",
+                       "VennDiagram", "ape", "MASS", "plotrix",
+                       "RColorBrewer", "scales"))
+
 Note that most issues with package installation can be resolved by switching to correct CRAN mirror.
 
-Dedicated windows binaries already have all R packages bundled, and the options summarized above 
+Dedicated windows binaries already have all R packages bundled, and the options summarized above
 should be considered only when troubleshooting R script execution issues.
-					   
+
 Compiling from source
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/sphinx/install.rst
+++ b/sphinx/install.rst
@@ -26,17 +26,28 @@ see the details (parameters, etc) for a specific routine execute
 
 .. code:: bash
 
-    java -jar vdjtools.jar RoutineName -h    
+    java -jar vdjtools.jar RoutineName -h
 
 Windows
 ~~~~~~~
 
-Dedicated VDJtools bundle can be downloaded from the 
-`release <https://github.com/mikessh/vdjtools/releases/latest>`__ section 
+Dedicated VDJtools bundle can be downloaded from the
+`release <https://github.com/mikessh/vdjtools/releases/latest>`__ section
 and is marked with ``.win.zip`` suffix.
 
-Linux/MacOS
-~~~~~~~~~~~
+Linux
+~~~~~
+
+A VDJtools bundle can be downloaded from the
+`release <https://github.com/mikessh/vdjtools/releases/latest>`__ section
+which includes the required vdjtools.jar file.
+
+All plotting is handled by R and will require several R packages some of
+which will be available via your distribution package manager.
+See :ref:`install-plotting` below.
+
+MacOS
+~~~~~
 
 Installation can be performed using `Homebrew <http://brew.sh/>`__ package manager:
 
@@ -49,12 +60,14 @@ Installation can be performed using `Homebrew <http://brew.sh/>`__ package manag
 Note that this sets ``vdjtools`` as a shortcut for ``java -jar vdjtools-X.X.X.jar``. JVM arguments
 such as ``-Xmx`` can be still passed to the script, e.g. ``vdjtools -Xmx20G CalcBasicStats ...``.
 
+.. _install-plotting:
+
 Setting up plotting routines
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 All plotting in VDJtools framework is performed via running R scripts.
 Therefore one needs to install `R <http://www.r-project.org/>`__
-programming language and make sure that the
+programming language and several of its packages.  Make sure that
 
 .. code:: bash
 
@@ -62,9 +75,48 @@ programming language and make sure that the
 
 runs successfully. Note that all R scripts were tested under R version 3.1.0.
 
-In case not using the pre-compiled ``*.win.zip`` package / Homebrew installation,
-one needs to additionally install R dependencies to a local library by
-running the :ref:`rinstall` routine:
+The pre-compiled ```*.win.zip`` includes all the required R packages
+and the homebrew installation will install them automatically.
+In all other cases the required packages need to be manually installed.
+
+These are the required packages:
+
+============  ===================
+CRAN package  Debian package
+============  ===================
+ape           r-cran-ape
+circlize
+FField
+ggplot2       r-cran-ggplot2
+gplots        r-cran-gplots
+grid
+gridExtra
+MASS          r-cran-mass
+plotrix       r-cran-plotrix
+RColorBrewer  r-cran-rcolorbrewer
+reshape       r-cran-reshape
+reshape2      r-cran-reshape2
+scales        r-cran-scales
+VennDiagram
+============  ===================
+
+If your Linux distribution includes pre-packaged versions of a package,
+those should be prefered.  The following will install the existing for
+Debian and Debian based distributions such as Ubuntu and Mint:
+
+.. code:: bash
+
+    apt-get install r-cran-ape r-cran-ggplot2 r-cran-gplots r-cran-mass \
+      r-cran-plotrix r-cran-rcolorbrewer r-cran-reshape r-cran-reshape2 \
+      r-cran-scales
+
+while the other packages will have to be installed via R itself:
+
+.. code:: r
+
+    install.packages(c("circlize", "grid", "gridExtra", "VennDiagram"))
+
+Alternatively, VDJtools has a ref:`Rinstall` routine:
 
 .. code:: bash
 


### PR DESCRIPTION
This fixes two issues:
1. the link to download java was incorrect. It was linking to JRE 1.7 which is not enough for vdjtools so I replaced with a latest type of link (instead of version specific link).
2. add instructions for Linux distributions. The existing instructions were mixed with Mac which would require linuxbrew installed (which is neither common or explained on the current documentation). I have added a table for the required R packages including distro specific package names. I do not have a fedora machine but tried to look for the required dependencies [online](https://apps.fedoraproject.org/packages/s/R) and would seem like it packages none (which means that they won't be available on their derivatives such as RHEL or CentOS).
